### PR TITLE
Allow MD5 hashed passwords, no password encryption and main website

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,10 +3,10 @@ FROM ubuntu:14.04
 ENV APP_ROOT /yourls
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN mkdir -p ${APP_ROOT} 
-RUN apt-get update \
-  && apt-get install -y --force-yes curl apache2 supervisor libapache2-mod-php5 php5-mysql \
-  && unset ${DEBIAN_FRONTEND} \
+RUN mkdir -p ${APP_ROOT} \
+  && apt-get update \
+  && apt-get install -y curl apache2 supervisor libapache2-mod-php5 php5-mysql \
+  && unset DEBIAN_FRONTEND \
   && rm -rf /var/lib/apt/lists/* \
   && curl -L https://github.com/YOURLS/YOURLS/archive/1.7.1.tar.gz | tar -zx -C ${APP_ROOT} --strip-components=1 \
   && php5enmod mysql \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN mkdir -p ${APP_ROOT} \
   && apt-get update \
   && apt-get install -y curl apache2 supervisor libapache2-mod-php5 php5-mysql \
-  && unset DEBIAN_FRONTEND \
+  && unset ${DEBIAN_FRONTEND} \
   && rm -rf /var/lib/apt/lists/* \
   && curl -L https://github.com/YOURLS/YOURLS/archive/1.7.1.tar.gz | tar -zx -C ${APP_ROOT} --strip-components=1 \
   && php5enmod mysql \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ FROM ubuntu:14.04
 ENV APP_ROOT /yourls
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN mkdir -p ${APP_ROOT} \
-  && apt-get update \
-  && apt-get install -y  --force-yes curl apache2 supervisor libapache2-mod-php5 php5-mysql \
+RUN mkdir -p ${APP_ROOT} 
+RUN apt-get update \
+  && apt-get install -y --force-yes curl apache2 supervisor libapache2-mod-php5 php5-mysql \
   && unset ${DEBIAN_FRONTEND} \
   && rm -rf /var/lib/apt/lists/* \
   && curl -L https://github.com/YOURLS/YOURLS/archive/1.7.1.tar.gz | tar -zx -C ${APP_ROOT} --strip-components=1 \
@@ -20,6 +20,7 @@ COPY docker/vhost.conf /etc/apache2/sites-enabled/000-default.conf
 COPY docker/config.php ${APP_ROOT}/user/config.php
 COPY docker/migrate.php ${APP_ROOT}/migrate.php
 COPY docker/.htaccess ${APP_ROOT}/.htaccess
+COPY docker/index.php ${APP_ROOT}/index.php
 
 WORKDIR ${APP_ROOT}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN mkdir -p ${APP_ROOT} \
   && apt-get update \
-  && apt-get install -y curl apache2 supervisor libapache2-mod-php5 php5-mysql \
+  && apt-get install -y  --force-yes curl apache2 supervisor libapache2-mod-php5 php5-mysql \
   && unset ${DEBIAN_FRONTEND} \
   && rm -rf /var/lib/apt/lists/* \
   && curl -L https://github.com/YOURLS/YOURLS/archive/1.7.1.tar.gz | tar -zx -C ${APP_ROOT} --strip-components=1 \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ db:
     - MYSQL_ROOT_PASSWORD=coolpassword
     - MYSQL_DATABASE=yourls
 web:
-  build: .
+  image: darmagedon/yourls:1.7
   ports:
     - "80:80"
   links:
@@ -18,4 +18,5 @@ web:
     - YOURLS_DB_HOST=db
     - YOURLS_DEBUG=false
     - YOURLS_USERS=default:default
-    - YOURLS_SITE=http://set-this-or-the-site-doesnt-work.com/my-blog.asp
+    - YOURLS_SITE=http://mysite.local.com/
+    - YOURL_INDEX_WEBSITE=https://www.lftechnology.com/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ db:
     - MYSQL_ROOT_PASSWORD=coolpassword
     - MYSQL_DATABASE=yourls
 web:
-  image: darmagedon/yourls:1.7
+  build: .
   ports:
     - "80:80"
   links:
@@ -18,5 +18,5 @@ web:
     - YOURLS_DB_HOST=db
     - YOURLS_DEBUG=false
     - YOURLS_USERS=default:default
-    - YOURLS_SITE=http://mysite.local.com/
-    - YOURL_INDEX_WEBSITE=https://www.lftechnology.com/
+    - YOURLS_SITE=http://set-this-or-the-site-doesnt-work.com
+    - YOURLS_INDEX_WEBSITE=https://github.com/

--- a/docker/config.php
+++ b/docker/config.php
@@ -85,6 +85,9 @@ define( 'YOURLS_URL_CONVERT', getenv('YOURLS_URL_CONVERT') ?: 32 );
  * 62: generates mixed case keywords (ie: 13jKm or 13JKm)
  * Stick to one setting. It's best not to change after you've started creating links.
  */
+/** OPTION to store plain text password. enabled by default
+*/
+define( 'YOURLS_NO_HASH_PASSWORD', getenv('YOURL_NO_HASH_PASSWORD') ?: true );
 
 /**
 * Reserved keywords (so that generated URLs won't match them)

--- a/docker/config.php
+++ b/docker/config.php
@@ -66,7 +66,7 @@ $yourls_user_passwords = [
 $yourls_user_passwords = [];
 
 foreach (explode(',', getenv('YOURLS_USERS')) as $creds) {
-  list($name, $pass) = explode(':', $creds);
+  list($name, $pass) = explode(':', $creds, 2);
   $yourls_user_passwords[$name] = $pass;
 }
 
@@ -85,6 +85,7 @@ define( 'YOURLS_URL_CONVERT', getenv('YOURLS_URL_CONVERT') ?: 32 );
  * 62: generates mixed case keywords (ie: 13jKm or 13JKm)
  * Stick to one setting. It's best not to change after you've started creating links.
  */
+
 /** OPTION to store plain text password. enabled by default
 */
 define( 'YOURLS_NO_HASH_PASSWORD', getenv('YOURL_NO_HASH_PASSWORD') ?: true );

--- a/docker/index.php
+++ b/docker/index.php
@@ -1,1 +1,1 @@
-<?php header('Location: getenv('YOURL_INDEX_WEBSITE') ?: http://openmrs.org/'); ?>
+<?php header("Location: ".(getenv('YOURLS_INDEX_WEBSITE') ?: "http://yourls.org/")); ?>

--- a/docker/index.php
+++ b/docker/index.php
@@ -1,0 +1,1 @@
+<?php header('Location: getenv('YOURL_INDEX_WEBSITE') ?: http://openmrs.org/'); ?>


### PR DESCRIPTION
This pull request implements three different things:

  - Enable YOURLS_NO_HASH_PASSWORD by default, as `config.php` cannot have the password encrypted.
  - Allow passwords to be passed as md5:salt:hash
  - Allow / to redirect to a desired website